### PR TITLE
Add string and nocall functions for Python expressions.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,12 +5,15 @@
 3.1.0 (unreleased)
 ===================
 
-- Added support for Python 3.6.
-- Dropped support for Python 3.3.
+- Add support for Python 3.6.
+- Drop support for Python 3.3.
 - Use the adapter namespace from ``zope.pagetemplate`` if it's
   available, instead of the backwards compatibility shim in
   ``zope.app.pagetemplate``. See `issue 3
   <https://github.com/zopefoundation/z3c.pt/issues/3>`_.
+- Add the ``string`` and ``nocall`` functions for use inside Python
+  expressions. See `issue 2
+  <https://github.com/zopefoundation/z3c.pt/issues/2>`_.
 
 
 3.0 (2016-09-02)

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,6 +7,10 @@
 
 - Added support for Python 3.6.
 - Dropped support for Python 3.3.
+- Use the adapter namespace from ``zope.pagetemplate`` if it's
+  available, instead of the backwards compatibility shim in
+  ``zope.app.pagetemplate``. See `issue 3
+  <https://github.com/zopefoundation/z3c.pt/issues/3>`_.
 
 
 3.0 (2016-09-02)

--- a/setup.py
+++ b/setup.py
@@ -37,6 +37,7 @@ def alltests():
     return unittest.TestSuite(suites)
 
 TESTS_REQUIRE = [
+    'zope.pagetemplate',
     'zope.testing',
     'zope.testrunner',
 ]

--- a/src/z3c/pt/README.rst
+++ b/src/z3c/pt/README.rst
@@ -390,7 +390,7 @@ Adapters build upon).
   ...     def parent(self):
   ...         return self.context.parent
 
-  >>> function_namespaces.registerFunctionNamespace('ns1', ns1)
+  >>> function_namespaces.namespaces['ns1'] = ns1
 
   >>> class ns2(object):
   ...     def __init__(self, context):

--- a/src/z3c/pt/__init__.py
+++ b/src/z3c/pt/__init__.py
@@ -1,9 +1,4 @@
-# See http://peak.telecommunity.com/DevCenter/setuptools#namespace-packages
-try:
-    __import__('pkg_resources').declare_namespace(__name__)
-except ImportError:
-    from pkgutil import extend_path
-    __path__ = extend_path(__path__, __name__)
+__import__('pkg_resources').declare_namespace(__name__)
 
 # Fix a Python 3 bug in Chameleon.
 import chameleon.i18n

--- a/src/z3c/pt/expressions.py
+++ b/src/z3c/pt/expressions.py
@@ -244,7 +244,7 @@ class PythonExpr(BasePythonExpr):
             tales=Builtin("tales"),
             name=ast.Str(s=name),
             mode="eval")
-        for name in ('path', 'exists')
+        for name in ('path', 'exists', 'string', 'nocall')
     }
 
     def __call__(self, target, engine):

--- a/src/z3c/pt/namespaces.py
+++ b/src/z3c/pt/namespaces.py
@@ -93,15 +93,21 @@ class AdapterNamespaces(object):
 
 
     def getFunctionNamespace(self, namespacename):
-        """ Returns the function namespace """
+        """
+        Returns the function namespace, if registered.
+
+        Unlike ``__getitem__``, this method will immediately raise a
+        KeyError if no such function is registered.
+        """
         return self.namespaces[namespacename]
 
-try:
-    # If zope.app.pagetemplates is available, use the adapter
-    # registered with the main zope.app.pagetemplates engine so that
-    # we don't need to re-register them.
-    from zope.app.pagetemplates.engine import Engine
-    function_namespaces = Engine.namespaces
-except (ImportError, AttributeError):
-    function_namespaces = AdapterNamespaces()
+function_namespaces = AdapterNamespaces()
 
+try:
+    # If zope.pagetemplate is available, use the adapter
+    # registered with the main zope.pagetemplate engine so that
+    # we don't need to re-register them.
+    from zope.pagetemplate.engine import Engine
+    function_namespaces = Engine.namespaces
+except (ImportError, AttributeError): # pragma: no cover
+    pass

--- a/src/z3c/pt/pagetemplate.py
+++ b/src/z3c/pt/pagetemplate.py
@@ -12,8 +12,9 @@
 #
 ##############################################################################
 import os
-import six
 import sys
+
+import six
 
 from zope import i18n
 from zope.security.proxy import ProxyFactory
@@ -28,7 +29,7 @@ from z3c.pt import expressions
 
 try:
     from Missing import MV
-    MV  # pyflakes
+    MV = MV  # pyflakes pragma: no cover
 except ImportError:
     MV = object()
 
@@ -53,13 +54,11 @@ class OpaqueDict(dict):
         inst.dictionary = dictionary
         return inst
 
-    @property
-    def __getitem__(self):
-        return self.dictionary.__getitem__
+    def __getitem__(self, name):
+        return self.dictionary[name]
 
-    @property
     def __len__(self):
-        return self.dictionary.__len__
+        return len(self.dictionary)
 
     def __repr__(self):
         return "{...} (%d entries)" % len(self)
@@ -67,19 +66,9 @@ class OpaqueDict(dict):
 sys_modules = ProxyFactory(OpaqueDict(sys.modules))
 
 
-class DummyRegistry(object):
-    """This class is for B/W with Chameleon 1.x API."""
-
-    @staticmethod
-    def purge():
-        pass
-
-
 class BaseTemplate(template.PageTemplate):
     content_type = None
     version = 2
-
-    registry = DummyRegistry()
 
     expression_types = {
         'python': expressions.PythonExpr,
@@ -133,16 +122,16 @@ class BaseTemplate(template.PageTemplate):
         if target_language is None:
             try:
                 target_language = i18n.negotiate(request)
-            except:
+            except Exception:
                 target_language = None
 
         context['target_language'] = target_language
 
         # bind translation-method to request
         def translate(
-            msgid, domain=None, mapping=None,
-            target_language=None, default=None,
-            context=None):
+                msgid, domain=None, mapping=None,
+                target_language=None, default=None,
+                context=None):
             if msgid is MV:
                 # Special case handling of Zope2's Missing.MV
                 # (Missing.Value) used by the ZCatalog but is
@@ -282,6 +271,9 @@ class BoundPageTemplate(object):
     """When a page template class is used as a property, it's bound to
     the class instance on access, which is implemented using this
     helper class."""
+
+    im_self = None
+    im_func = None
 
     def __init__(self, pt, render):
         object.__setattr__(self, 'im_self', pt)

--- a/src/z3c/pt/pagetemplate.py
+++ b/src/z3c/pt/pagetemplate.py
@@ -135,7 +135,13 @@ class BaseTemplate(template.PageTemplate):
             if msgid is MV:
                 # Special case handling of Zope2's Missing.MV
                 # (Missing.Value) used by the ZCatalog but is
-                # unhashable
+                # unhashable.
+
+                # This case cannot arise in ordinary templates; msgid
+                # comes from i18n:translate attributes, which does not
+                # take a TALES expression, just a literal string.
+                # However, the 'context' argument is available as an implementation
+                # detail for macros
                 return
             return fast_translate(
                 msgid, domain, mapping, request, target_language, default)

--- a/src/z3c/pt/tests/test_expressions.py
+++ b/src/z3c/pt/tests/test_expressions.py
@@ -141,6 +141,10 @@ class TestPathExpr(CleanUp,
         translated = expr.translate("a/?var/?var2", None)
         self.assertEqual(len(translated), 1)
         code = TemplateCodeGenerator(translated[0]).code
+        # XXX: Normally this starts with 'None =', but sometimes on Python 2,
+        # at least in tox, it starts with '__package__ ='. Why
+        # is this?
+        code = code.strip().replace("__package__", 'None')
         self.assertEqual(
-            code.strip(),
+            code,
             "None = _path_traverse(a, econtext, True, (('%s' % (var, )), ('%s' % (var2, )), ))")

--- a/src/z3c/pt/tests/test_expressions.py
+++ b/src/z3c/pt/tests/test_expressions.py
@@ -1,0 +1,146 @@
+# -*- coding: utf-8 -*-
+"""
+Tests for expressions.py
+
+"""
+import unittest
+
+from zope.testing.cleanup import CleanUp
+
+from z3c.pt import expressions
+
+# pylint:disable=protected-access
+
+class TestRenderContentProvider(CleanUp,
+                                unittest.TestCase):
+
+    def test_not_found(self):
+        from zope.contentprovider.interfaces import ContentProviderLookupError
+
+        context = object()
+        request = object()
+        view = object()
+        name = 'a provider'
+        econtext = {'context': context, 'request': request, 'view': view}
+
+        with self.assertRaises(ContentProviderLookupError) as exc:
+            expressions.render_content_provider(econtext, name)
+
+        e = exc.exception
+        self.assertEqual(e.args,
+                         (name, (context, request, view)))
+
+    def test_sets_ilocation_name(self):
+        from zope import component
+        from zope import interface
+        from zope.location.interfaces import ILocation
+        from zope.contentprovider.interfaces import IContentProvider
+
+        attrs = {}
+
+        @interface.implementer(ILocation, IContentProvider)
+        class Provider(object):
+            def __init__(self, *args):
+                pass
+
+            def __setattr__(self, name, value):
+                attrs[name] = value
+
+            update = render = lambda s: None
+
+        component.provideAdapter(Provider,
+                                 adapts=(object, object, object),
+                                 provides=IContentProvider,
+                                 name='a provider')
+
+        context = object()
+        request = object()
+        view = object()
+        econtext = {'context': context, 'request': request, 'view': view}
+
+        expressions.render_content_provider(econtext, 'a provider')
+
+        self.assertEqual(attrs, {'__name__': 'a provider'})
+
+
+class TestPathExpr(CleanUp,
+                   unittest.TestCase):
+
+    def test_translate_empty_string(self):
+        import ast
+
+        expr = expressions.PathExpr('')
+        result = expr.translate('', 'foo')
+
+        self.assertEqual(len(result),
+                         1)
+        self.assertIsInstance(result[0], ast.Assign)
+
+    def test_translate_invalid_path(self):
+        from chameleon.exc import ExpressionError
+
+        expr = expressions.PathExpr('')
+        with self.assertRaises(ExpressionError):
+            expr.translate('not valid', None)
+
+    def test_translate_components(self):
+        from chameleon.codegen import TemplateCodeGenerator
+        from chameleon.astutil import ASTCodeGenerator
+        from chameleon.astutil import node_annotations
+        expr = expressions.PathExpr('')
+        comps = expr._find_translation_components(['a'])
+
+        # First component is skipped
+        self.assertEqual(comps, [])
+
+        # Single literal
+        comps = expr._find_translation_components(['a', 'b'])
+        self.assertEqual([s.s for s in comps], ['b'])
+
+        # Multiple literals
+        comps = expr._find_translation_components(['a', 'b', 'c'])
+        self.assertEqual([s.s for s in comps], ['b', 'c'])
+
+        # Single interpolation---must be longer than one character
+        comps = expr._find_translation_components(['a', '?b'])
+        self.assertEqual([s.s for s in comps], ['?b'])
+
+        comps = expr._find_translation_components(['a', '?var'])
+        self.assertEqual(len(comps), 1)
+        code = ASTCodeGenerator(comps[0]).code
+        self.assertEqual(code, '(format % args)')
+        code = TemplateCodeGenerator(comps[0]).code
+        self.assertEqual(code, "('%s' % (var, ))")
+
+        args = node_annotations[comps[0].right]
+        code = TemplateCodeGenerator(args).code
+        self.assertEqual(code, '(var, )')
+
+
+        # Multiple interpolations
+        comps = expr._find_translation_components(['a', '?var', "?var2"])
+        self.assertEqual(len(comps), 2)
+        code = ASTCodeGenerator(comps[0]).code
+        self.assertEqual(code, '(format % args)')
+        code = TemplateCodeGenerator(comps[0]).code
+        self.assertEqual(code, "('%s' % (var, ))")
+
+        args = node_annotations[comps[0].right]
+        code = TemplateCodeGenerator(args).code
+        self.assertEqual(code, '(var, )')
+
+        code = ASTCodeGenerator(comps[1]).code
+        self.assertEqual(code, '(format % args)')
+        code = TemplateCodeGenerator(comps[1]).code
+        self.assertEqual(code, "('%s' % (var2, ))")
+
+        args = node_annotations[comps[1].right]
+        code = TemplateCodeGenerator(args).code
+        self.assertEqual(code, '(var2, )')
+
+        translated = expr.translate("a/?var/?var2", None)
+        self.assertEqual(len(translated), 1)
+        code = TemplateCodeGenerator(translated[0]).code
+        self.assertEqual(
+            code.strip(),
+            "None = _path_traverse(a, econtext, True, (('%s' % (var, )), ('%s' % (var2, )), ))")

--- a/src/z3c/pt/tests/test_namespaces.py
+++ b/src/z3c/pt/tests/test_namespaces.py
@@ -1,0 +1,34 @@
+# -*- coding: utf-8 -*-
+"""
+Tests for namespaces.py.
+
+"""
+
+import unittest
+
+from z3c.pt import namespaces
+
+class TestAdapterNamespaces(unittest.TestCase):
+
+    def test_registered_name(self):
+        nss = namespaces.AdapterNamespaces()
+        func = lambda ctx: ctx
+        nss.registerFunctionNamespace('ns', func)
+        self.assertIs(func, nss['ns'])
+        self.assertIs(func, nss.getFunctionNamespace('ns'))
+
+    def test_unregistered_name(self):
+        nss = namespaces.AdapterNamespaces()
+        with self.assertRaises(KeyError):
+            nss.getFunctionNamespace('ns')
+
+        # but __getitem__ makes one up
+        self.assertIsNotNone(nss['ns'])
+
+    def test_using_pagetemplate_version(self):
+        from zope.pagetemplate import engine
+
+        self.assertFalse(isinstance(namespaces.function_namespaces,
+                                    namespaces.AdapterNamespaces))
+        self.assertIsInstance(namespaces.function_namespaces,
+                              engine.AdapterNamespaces)

--- a/src/z3c/pt/tests/test_templates.py
+++ b/src/z3c/pt/tests/test_templates.py
@@ -28,6 +28,26 @@ class Setup(CleanUp):
         import z3c.pt
         zope.configuration.xmlconfig.file('configure.zcml', z3c.pt)
 
+class TestPageTemplate(Setup,
+                       unittest.TestCase):
+
+    def test_string_function(self):
+        template = pagetemplate.PageTemplate('''<div tal:content="python:string('a string')" />''')
+        result = template.render()
+        self.assertEqual(result,
+                         '<div>a string</div>')
+
+    def test_nocall_function(self):
+        class Call(object):
+            def __call__(self):
+                raise AssertionError("Should not be called")
+            def __str__(self):
+                return "Not Called"
+        arg = {'call': Call()}
+        template = pagetemplate.PageTemplate('''<div tal:content="python:nocall('arg/call')" />''')
+        result = template.render(arg=arg)
+        self.assertEqual(result,
+                         '<div>Not Called</div>')
 
 class TestPageTemplateFile(Setup,
                            unittest.TestCase):

--- a/src/z3c/pt/tests/test_templates.py
+++ b/src/z3c/pt/tests/test_templates.py
@@ -30,7 +30,7 @@ class TestPageTemplateFile(unittest.TestCase):
         from z3c.pt.pagetemplate import PageTemplateFile
         template = PageTemplateFile("nocall.pt")
         def dont_call():
-            raise RuntimeError()
+            raise AssertionError("Should not be called")
         result = template(callable=dont_call)
         self.assertTrue(repr(dont_call) in result)
 
@@ -38,7 +38,7 @@ class TestPageTemplateFile(unittest.TestCase):
         from z3c.pt.pagetemplate import PageTemplateFile
         template = PageTemplateFile("exists.pt")
         def dont_call():
-            raise RuntimeError()
+            raise AssertionError("Should not be called")
         result = template(callable=dont_call)
         self.assertTrue('ok' in result)
 

--- a/tox.ini
+++ b/tox.ini
@@ -14,7 +14,7 @@ basepython =
     python2.7
 commands =
     coverage run -m zope.testrunner --test-path=src []
-    coverage report --fail-under=93
+    coverage report --fail-under=100
 deps =
     {[testenv]deps}
     coverage


### PR DESCRIPTION
Fixes #2.

Currently based on #7 because there would be conflicts otherwise. Only the tip commit is relevant.