### PR TITLE
Test fixups

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,8 +5,7 @@
 4.2 (unreleased)
 ================
 
-- Nothing changed yet.
-
+- Updated test suite to be compatible with newer Chameleon releases.
 
 4.1 (2024-01-09)
 ================

--- a/src/z3c/pt/expressions.py
+++ b/src/z3c/pt/expressions.py
@@ -149,7 +149,7 @@ class PathExpr(TalesExpr):
 
     traverser = Symbol(path_traverse)
 
-    def _find_translation_components(self, parts):
+    def _find_components(self, parts):
         components = []
         for part in parts[1:]:
             interpolation_args = []
@@ -200,7 +200,7 @@ class PathExpr(TalesExpr):
         # note that unicode paths are not allowed
         parts = str(path).split("/")
 
-        components = self._find_translation_components(parts)
+        components = self._find_components(parts)
 
         base = parts[0]
 

--- a/src/z3c/pt/expressions.py
+++ b/src/z3c/pt/expressions.py
@@ -19,7 +19,6 @@ import zope.event
 from chameleon.astutil import Builtin
 from chameleon.astutil import NameLookupRewriteVisitor
 from chameleon.astutil import Symbol
-from chameleon.astutil import load
 from chameleon.codegen import template
 from chameleon.exc import ExpressionError
 from chameleon.tales import ExistsExpr as BaseExistsExpr
@@ -169,7 +168,9 @@ class PathExpr(TalesExpr):
                     "format % args",
                     format=ast.Str(part),
                     args=ast.Tuple(
-                        list(map(load, interpolation_args)), ast.Load()
+                        [ast.Name(arg, ctx=ast.Load())
+                         for arg in interpolation_args],
+                        ast.Load(),
                     ),
                     mode="eval",
                 )
@@ -213,8 +214,8 @@ class PathExpr(TalesExpr):
         call = template(
             "traverse(base, econtext, call, path_items)",
             traverse=self.traverser,
-            base=load(base),
-            call=load(str(not nocall)),
+            base=base,
+            call=str(not nocall),
             path_items=ast.Tuple(elts=components),
             mode="eval",
         )


### PR DESCRIPTION
The previous test relied on implementation details.

We're able to write these tests in a more simple way using testing functionality that comes with Chameleon.

Another motivation is that some of the previously used imports have been removed from Chameleon such that these tests would break – but these also were something of a misunderstanding here in these tests, really testing the implementation rather than the behavior.