### PR TITLE
Switch to PEP 420 native namespace.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,7 @@
 5.0 (unreleased)
 ================
 
-- Nothing changed yet.
+- Drop support for ``pkg_resources`` namespace and replace it with PEP 420 native namespace. Caution: This change requires to switch all packages in the namespace of the package to versions using a PEP 420 namespace.
 
 
 4.5 (2025-03-24)

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -2,7 +2,7 @@
  Changelog
 ===========
 
-4.6 (unreleased)
+5.0 (unreleased)
 ================
 
 - Nothing changed yet.

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ def read(*filenames):
 
 setup(
     name="z3c.pt",
-    version='4.6.dev0',
+    version='5.0.dev0',
     author="Malthe Borch and the Zope Community",
     author_email="zope-dev@zope.dev",
     description="Fast ZPT engine.",

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,6 @@
 """
 import os
 
-from setuptools import find_packages
 from setuptools import setup
 
 
@@ -63,9 +62,6 @@ setup(
         'Sources': 'https://github.com/zopefoundation/z3c.pt',
         'Issue Tracker': 'https://github.com/zopefoundation/z3c.pt/issues',
     },
-    namespace_packages=["z3c"],
-    packages=find_packages("src"),
-    package_dir={"": "src"},
     python_requires='>=3.9',
     install_requires=[
         "setuptools",
@@ -80,7 +76,7 @@ setup(
         "test": [
             "zope.pagetemplate",
             "zope.testing",
-            "zope.testrunner",
+            "zope.testrunner >= 6.4",
         ],
         "docs": [
             "Sphinx",

--- a/src/z3c/__init__.py
+++ b/src/z3c/__init__.py
@@ -1,1 +1,0 @@
-__import__("pkg_resources").declare_namespace(__name__)  # pragma: no cover

--- a/src/z3c/pt/__init__.py
+++ b/src/z3c/pt/__init__.py
@@ -1,5 +1,3 @@
-__import__("pkg_resources").declare_namespace(__name__)
-
 # Fix a NameError in Chameleon.
 import chameleon.i18n  # noqa: E402
 


### PR DESCRIPTION
- **Bumped version for breaking release.**
- **Drop support for ``pkg_resources`` namespace and replace it with PEP 420 native namespace. Caution: This change requires to switch all packages in the namespace of the package to versions using a PEP 420 namespace.**
- **Switch to PEP 420 native namespace.**
